### PR TITLE
Fix FGW test path and refresh README

### DIFF
--- a/hybrid/tests/test_fgw_pipeline.py
+++ b/hybrid/tests/test_fgw_pipeline.py
@@ -8,9 +8,9 @@ import pytest
 
 np = pytest.importorskip("numpy")
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from hybrid.fgw_pipeline import compare_phages_fgw
 


### PR DESCRIPTION
## Summary
- ensure the FGW regression test adds the repository root to sys.path so imports work when running pytest
- rewrite the README to describe the hybrid sampler, FGW pipeline, dependencies, and usage examples

## Testing
- pytest hybrid/tests/test_fgw_pipeline.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f85e952c048324bd6925a1102b12dd