### PR TITLE
Ensure temporary run TSV files are deleted after consensus output

### DIFF
--- a/hybrid/phage_segmenter.py
+++ b/hybrid/phage_segmenter.py
@@ -732,10 +732,9 @@ def main() -> None:
     )
     for path in run_paths:
         try:
-            path.unlink(missing_ok=True)
-        except AttributeError:
-            if path.exists():
-                path.unlink()
+            path.unlink()
+        except FileNotFoundError:
+            continue
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure the per-run TSV outputs are deleted after generating the consensus report by relying on FileNotFoundError handling instead of `missing_ok`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8762f21508324886a4be0825ed13e